### PR TITLE
Ticket2844: Upgrade galil macros

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -25,14 +25,6 @@ import unittest
 import xmlrunner
 import argparse
 
-from test.test_upgrade_step_from_3p2p1 import TestUpgradeStepFrom3p2p1
-from test.test_upgrade_step_from_3p2p1p1 import TestUpgradeStepFrom3p2p1p1
-from test.test_upgrade_step_from_3p2p1p2 import TestUpgradeStepFrom3p2p1p2
-from test.test_upgrade_step_from_4p1p0 import TestUpgradeStepFrom4p1p0
-from test.test_upgrade_base import TestUpgradeBase
-from test.test_add_to_base_iocs import TestAddToBaseIOCs
-from test.test_config_filter import TestConfigFilter
-
 DEFAULT_DIRECTORY = os.path.join('..', '..', '..', 'test-reports')
 
 if __name__ == '__main__':
@@ -44,21 +36,12 @@ if __name__ == '__main__':
     xml_dir = args.output_dir[0]
 
     # Load tests from test suites
-    suites = [
-        unittest.TestLoader().loadTestsFromTestCase(TestUpgradeBase),
-        unittest.TestLoader().loadTestsFromTestCase(TestAddToBaseIOCs),
-        unittest.TestLoader().loadTestsFromTestCase(TestConfigFilter),
-        unittest.TestLoader().loadTestsFromTestCase(TestUpgradeStepFrom3p2p1),
-        unittest.TestLoader().loadTestsFromTestCase(TestUpgradeStepFrom3p2p1p1),
-        unittest.TestLoader().loadTestsFromTestCase(TestUpgradeStepFrom3p2p1p2),
-        unittest.TestLoader().loadTestsFromTestCase(TestUpgradeStepFrom4p1p0),
-
-    ]
+    test_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "test"))
+    test_suite = unittest.TestLoader().discover(test_dir, pattern="test_*.py")
 
     print("\n\n------ BEGINNING UPGRADE STEPS UNIT TESTS ------")
-
-    ret_vals = [xmlrunner.XMLTestRunner(output=xml_dir).run(s).wasSuccessful() for s in suites]
-
+    ret_vals = xmlrunner.XMLTestRunner(output=xml_dir).run(test_suite)
     print("------ UPGRADE STEPS UNIT TESTS COMPLETE ------\n\n")
+
     # Return failure exit code if a test failed
-    sys.exit(False in ret_vals)
+    sys.exit(bool(ret_vals.errors or ret_vals.failures))

--- a/run_tests.py
+++ b/run_tests.py
@@ -33,7 +33,7 @@ from test.test_upgrade_base import TestUpgradeBase
 from test.test_add_to_base_iocs import TestAddToBaseIOCs
 from test.test_config_filter import TestConfigFilter
 
-DEFAULT_DIRECTORY = os.path.join('..', '..', '..', '..', 'test-reports')
+DEFAULT_DIRECTORY = os.path.join('..', '..', '..', 'test-reports')
 
 if __name__ == '__main__':
     # get output directory from command line arguments

--- a/src/common_upgrades/config_filter.py
+++ b/src/common_upgrades/config_filter.py
@@ -27,7 +27,7 @@ class ConfigFilter():
             Tuple: The path to the ioc file and it's xml representation
         """
         for path in [COMPONENT_FOLDER, CONFIG_FOLDER]:
-            for config in [config for config in self._file_access.listdir(path) if os.path.isdir(config)]:
+            for config in [c for c in self._file_access.listdir(path) if self._file_access.is_dir(c)]:
                 ioc_path = os.path.join(config, IOC_FILE)
                 try:
                     yield (ioc_path, self._file_access.open_xml_file(ioc_path))

--- a/src/file_access.py
+++ b/src/file_access.py
@@ -118,3 +118,15 @@ class FileAccess(object):
         """
         self._logger.info("Removing file {}".format(filename))
         os.remove(os.path.join(self.config_base, filename))
+
+    def is_dir(self, path):
+        """
+        Checks whether a path is a directory or file.
+
+        Args:
+            path (str): The path relative to the configuration directory.
+
+        Returns:
+            True if is a directory, false otherwise.
+        """
+        return os.path.isdir(os.path.join(self.config_base, path))

--- a/test/mother.py
+++ b/test/mother.py
@@ -53,6 +53,9 @@ class FileAccessStub(object):
     def remove_file(self, filename):
         pass
 
+    def is_dir(self, path):
+        pass
+
 
 def create_xml_with_iocs(iocs):
     """

--- a/test/test_upgrade_step_from_4p1p0.py
+++ b/test/test_upgrade_step_from_4p1p0.py
@@ -135,23 +135,23 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         assert_that(len(mtrctrl_xml), is_(1))
         assert_that(mtrctrl_xml[0].get("value"), is_("03"))
 
-    def test_WHEN_changed_galil_files_THEN_loads_galil_files(self):
+    def test_WHEN_changed_cmd_files_THEN_loads_all_cmd_files(self):
         open_file_mock = Mock(return_value="")
         self.file_access.open_file = open_file_mock
-        galil_files = ["galil2.cmd", "galil10.cmd"]
-        files = ["jaws.cmd", "other.o"] + galil_files
+        cmd_files = ["galil2.cmd", "galil10.cmd", "jaws.cmd"]
+        files = ["other.o", "another.cmdp"] + cmd_files
         self.file_access.listdir = Mock(return_value=[os.path.join("configurations", "gailil", f) for f in files])
 
-        self.upgrade_step.change_galil_files(self.file_access, self.logger)
+        self.upgrade_step.change_cmd_files(self.file_access, self.logger)
 
         assert_that(open_file_mock.call_args_list, is_(
-            [call(os.path.join("configurations", "gailil", f)) for f in galil_files]))
+            [call(os.path.join("configurations", "gailil", f)) for f in cmd_files]))
 
-    def _set_up_galil_dir_and_change(self, galil_files):
+    def _set_up_galil_dir_and_change(self, cmd_files):
         self.file_access.open_file = Mock(return_value="")
-        self.file_access.listdir = Mock(return_value=(["jaws.cmd", "other.o"] + galil_files))
+        self.file_access.listdir = Mock(return_value=(["other.o", "another.cmdp"] + cmd_files))
 
-        self.upgrade_step.change_galil_files(self.file_access, self.logger)
+        self.upgrade_step.change_cmd_files(self.file_access, self.logger)
 
     def test_GIVEN_galil1_cmd_WHEN_change_galil_files_THEN_saved_as_galil01_cmd(self):
         self._set_up_galil_dir_and_change(["galil1.cmd"])
@@ -171,7 +171,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         expected = os.path.join("configurations", "galil", "galil10.cmd")
         assert_that(self.file_access.write_filename, is_(expected))
 
-    def test_GIVEN_two_galil_cmd_WHEN_change_galil_files_THEN_both_saved_as_new_style(self):
+    def test_GIVEN_two_galil_cmd_WHEN_change_cmd_files_THEN_both_saved_as_new_style(self):
         self.file_access.write_file = Mock()
         self._set_up_galil_dir_and_change(["galil2.cmd", "galil05.cmd"])
 
@@ -183,7 +183,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         self.file_access.open_file = Mock(return_value=[TEST_STRING.format("GALILADDR03")])
         self.file_access.listdir = Mock(return_value=[os.path.join("configurations", "galil", "galil3.cmd")])
 
-        self.upgrade_step.change_galil_files(self.file_access, self.logger)
+        self.upgrade_step.change_cmd_files(self.file_access, self.logger)
 
         assert_that(self.file_access.write_file.call_args[0][1], is_([TEST_STRING.format("GALILADDR")]))
 
@@ -192,7 +192,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         self.file_access.open_file = Mock(return_value=[TEST_STRING.format("GALILADDR10")])
         self.file_access.listdir = Mock(return_value=[os.path.join("configurations", "galil", "galil3.cmd")])
 
-        self.upgrade_step.change_galil_files(self.file_access, self.logger)
+        self.upgrade_step.change_cmd_files(self.file_access, self.logger)
 
         assert_that(self.file_access.write_file.call_args[0][1], is_([TEST_STRING.format("GALILADDR")]))
 
@@ -201,7 +201,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         self.file_access.open_file = Mock(return_value=[TEST_STRING.format("GALILADDR")])
         self.file_access.listdir = Mock(return_value=[os.path.join("configurations", "galil", "galil3.cmd")])
 
-        self.upgrade_step.change_galil_files(self.file_access, self.logger)
+        self.upgrade_step.change_cmd_files(self.file_access, self.logger)
 
         assert_that(self.file_access.write_file.call_args[0][1], is_([TEST_STRING.format("GALILADDR")]))
 
@@ -211,7 +211,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         self.file_access.open_file = Mock(return_value="")
         self.file_access.listdir = Mock(return_value=[old_cmd])
 
-        self.upgrade_step.change_galil_files(self.file_access, self.logger)
+        self.upgrade_step.change_cmd_files(self.file_access, self.logger)
 
         self.file_access.remove_file.assert_called_with(old_cmd)
 
@@ -220,9 +220,33 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         self.file_access.open_file = Mock(return_value="")
         self.file_access.listdir = Mock(return_value=[os.path.join("configurations", "galil", "galil10.cmd")])
 
-        self.upgrade_step.change_galil_files(self.file_access, self.logger)
+        self.upgrade_step.change_cmd_files(self.file_access, self.logger)
 
         self.file_access.remove_file.assert_not_called()
+
+    def test_GIVEN_cmd_with_IFDMC01_WHEN_change_cmd_files_THEN_changed_to_IFIOC_GALIL_01(self):
+        self.file_access.write_file = Mock()
+        self.file_access.open_file = Mock(return_value=[TEST_STRING.format("$(IFDMC01)")])
+        self.file_access.listdir = Mock(return_value=[os.path.join("configurations", "galil", "jaws.cmd")])
+
+        self.upgrade_step.change_cmd_files(self.file_access, self.logger)
+
+        assert_that(self.file_access.write_file.call_args[0][1], is_([TEST_STRING.format("$(IFIOC_GALIL_01)")]))
+
+    def test_GIVEN_cmd_with_IFDMC15_WHEN_change_cmd_files_THEN_changed_to_IFIOC_GALIL_15(self):
+        self.file_access.write_file = Mock()
+        self.file_access.open_file = Mock(return_value=[TEST_STRING.format("$(IFDMC15)")])
+        self.file_access.listdir = Mock(return_value=[os.path.join("configurations", "galil", "jaws.cmd")])
+
+        self.upgrade_step.change_cmd_files(self.file_access, self.logger)
+
+        assert_that(self.file_access.write_file.call_args[0][1], is_([TEST_STRING.format("$(IFIOC_GALIL_15)")]))
+
+    def test_GIVEN_generic_cmd_WHEN_change_cmd_files_THEN_file_name_unchanged(self):
+        filename = "jaws.cmd"
+        self._set_up_galil_dir_and_change([filename])
+
+        assert_that(self.file_access.write_filename, is_(filename))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_upgrade_step_from_4p1p0.py
+++ b/test/test_upgrade_step_from_4p1p0.py
@@ -71,15 +71,15 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
 
         assert_that(self.file_access.write_file_contents, is_(xml))
 
-    def test_GIVEN_galiladdr_already_present_and_mtrctrl_not_present_WHEN_replaced_THEN_error_logged_and_nothing_saved(self):
+    def test_GIVEN_galiladdr_already_present_and_mtrctrl_not_present_WHEN_replaced_THEN_info_logged_and_nothing_saved(self):
         xml = IOC_FILE_XML.format(iocs=create_galil_ioc(1, {"GALILADDR": ""}))
         self.file_access.open_file = Mock(side_effect=[xml, "<a/>"])
         self.file_access.write_file = Mock()
         self.file_access.is_dir = Mock(return_value=True)
         self.upgrade_step.change_ioc_macros(self.file_access, self.logger)
 
-        assert_that(len(self.logger.log), is_(1), "Contains info {}".format(self.logger.log))
-        assert_that(len(self.logger.log_err), is_(1), "Contains error {}".format(self.logger.log_err))
+        assert_that(len(self.logger.log), is_(2), "Contains info {}".format(self.logger.log))
+        assert_that(len(self.logger.log_err), is_(0), "Contains error {}".format(self.logger.log_err))
 
         self.file_access.write_file.assert_not_called()
 

--- a/test/test_upgrade_step_from_4p1p0.py
+++ b/test/test_upgrade_step_from_4p1p0.py
@@ -41,9 +41,28 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         self.upgrade_step = UpgradeStepFrom4p1p0()
         self.logger = LoggingStub()
 
+    def test_GIVEN_a_file_in_the_configuration_directory_WHEN_searched_THEN_it_is_not_opened(self):
+        self.file_access.open_file = Mock()
+        self.file_access.is_dir = Mock(return_value=False)
+
+        self.upgrade_step.change_ioc_macros(self.file_access, self.logger)
+
+        self.file_access.open_file.assert_not_called()
+
+    def test_GIVEN_config_in_the_configuration_directory_WHEN_searched_THEN_ioc_file_opened(self):
+        config_name = "TEST_CONFIG"
+        self.file_access.open_file = Mock()
+        self.file_access.is_dir = Mock(return_value=True)
+        self.file_access.listdir = Mock(return_value=[config_name])
+
+        self.upgrade_step.change_ioc_macros(self.file_access, self.logger)
+
+        self.file_access.open_file.assert_called_once_with(os.path.join(config_name, "iocs.xml"))
+
     def test_GIVEN_galiladdr_and_mtrctrl_already_present_WHEN_replaced_THEN_warning_logged_and_no_change_made(self):
         xml = IOC_FILE_XML.format(iocs=create_galil_ioc(1, {"GALILADDR": "", "MTRCTRL": ""}))
         self.file_access.open_file = Mock(side_effect=[xml, "<a/>"])
+        self.file_access.is_dir = Mock(return_value=True)
 
         self.upgrade_step.change_ioc_macros(self.file_access, self.logger)
 
@@ -56,6 +75,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         xml = IOC_FILE_XML.format(iocs=create_galil_ioc(1, {"GALILADDR": ""}))
         self.file_access.open_file = Mock(side_effect=[xml, "<a/>"])
         self.file_access.write_file = Mock()
+        self.file_access.is_dir = Mock(return_value=True)
         self.upgrade_step.change_ioc_macros(self.file_access, self.logger)
 
         assert_that(len(self.logger.log), is_(1), "Contains info {}".format(self.logger.log))
@@ -66,6 +86,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
     def test_GIVEN_old_galiladdr_present_and_mtrctrl_present_WHEN_replaced_THEN_error_logged_and_no_change_made(self):
         xml = IOC_FILE_XML.format(iocs=create_galil_ioc(1, {"GALILADDR01": "", "MTRCTRL": ""}))
         self.file_access.open_file = Mock(side_effect=[xml, "<a/>"])
+        self.file_access.is_dir = Mock(return_value=True)
         self.file_access.write_file = Mock()
 
         self.upgrade_step.change_ioc_macros(self.file_access, self.logger)
@@ -79,6 +100,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         xml = IOC_FILE_XML.format(iocs=create_galil_ioc(1, {"GALILADDR01": "", "GALILADDR02": ""}))
         self.file_access.write_file = Mock()
         self.file_access.open_file = Mock(side_effect=[xml, "<a/>"])
+        self.file_access.is_dir = Mock(return_value=True)
 
         self.upgrade_step.change_ioc_macros(self.file_access, self.logger)
 
@@ -90,6 +112,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
     def test_GIVEN_old_galilarr01_WHEN_replaced_THEN_mtrcrtl_contains_01(self):
         xml = IOC_FILE_XML.format(iocs=create_galil_ioc(1, {"GALILADDR01": ""}))
         self.file_access.open_file = Mock(side_effect=[xml, "<a/>"])
+        self.file_access.is_dir = Mock(return_value=True)
 
         self.upgrade_step.change_ioc_macros(self.file_access, self.logger)
 
@@ -102,6 +125,7 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
     def test_GIVEN_old_galilarr03_WHEN_replaced_THEN_mtrcrtl_contains_03(self):
         xml = IOC_FILE_XML.format(iocs=create_galil_ioc(1, {"GALILADDR03": ""}))
         self.file_access.open_file = Mock(side_effect=[xml, "<a/>"])
+        self.file_access.is_dir = Mock(return_value=True)
 
         self.upgrade_step.change_ioc_macros(self.file_access, self.logger)
 
@@ -199,7 +223,6 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
         self.upgrade_step.change_galil_files(self.file_access, self.logger)
 
         self.file_access.remove_file.assert_not_called()
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/2844

To test:
* Confirm unit tests run
* Run the upgrade script and check that any *.cmd files in configurations/galil have $(IFDMCXX) changed to $(IF_IOC_GALIL_XX)

Once merged move https://github.com/ISISComputingGroup/IBEX/issues/2857