### PR TITLE
Ticket2868

### DIFF
--- a/src/file_access.py
+++ b/src/file_access.py
@@ -130,3 +130,6 @@ class FileAccess(object):
             True if is a directory, false otherwise.
         """
         return os.path.isdir(os.path.join(self.config_base, path))
+
+    def exists(self, path):
+        return os.path.exists(os.path.join(self.config_base, path))

--- a/src/upgrade_step_from_4p1p0.py
+++ b/src/upgrade_step_from_4p1p0.py
@@ -74,6 +74,9 @@ class UpgradeStepFrom4p1p0(UpgradeStep):
             file_access (FileAccess): file access
             logger (Logger): logger
         """
+        if not os.path.exists(GALIL_FOLDER):
+            return 0  # Nothing to be done in this case
+
         dirs = file_access.listdir(GALIL_FOLDER)
         for filename in dirs:
             if re.search(CMD_REGEX, filename):

--- a/src/upgrade_step_from_4p1p0.py
+++ b/src/upgrade_step_from_4p1p0.py
@@ -75,6 +75,7 @@ class UpgradeStepFrom4p1p0(UpgradeStep):
             logger (Logger): logger
         """
         if not os.path.exists(GALIL_FOLDER):
+            logger.info("No galil directory present ({})".format(GALIL_FOLDER))
             return 0  # Nothing to be done in this case
 
         dirs = file_access.listdir(GALIL_FOLDER)

--- a/src/upgrade_step_from_4p1p0.py
+++ b/src/upgrade_step_from_4p1p0.py
@@ -74,7 +74,7 @@ class UpgradeStepFrom4p1p0(UpgradeStep):
             file_access (FileAccess): file access
             logger (Logger): logger
         """
-        if not os.path.exists(GALIL_FOLDER):
+        if not file_access.exists(GALIL_FOLDER):
             logger.info("No galil directory present ({})".format(GALIL_FOLDER))
             return 0  # Nothing to be done in this case
 

--- a/test/mother.py
+++ b/test/mother.py
@@ -56,6 +56,9 @@ class FileAccessStub(object):
     def is_dir(self, path):
         pass
 
+    def exists(self, path):
+        return True
+
 
 def create_xml_with_iocs(iocs):
     """

--- a/test/test_upgrade_step_from_4p1p0.py
+++ b/test/test_upgrade_step_from_4p1p0.py
@@ -248,5 +248,14 @@ class TestUpgradeStepFrom4p1p0(unittest.TestCase):
 
         assert_that(self.file_access.write_filename, is_(filename))
 
+    def test_GIVEN_galil_settings_directory_does_not_exist_THEN_no_error_in_upgrade(self):
+        self.file_access.exists = Mock(return_value=False)
+        self.logger = Mock()
+
+        return_status = self.upgrade_step.change_cmd_files(self.file_access, self.logger)
+        self.assertEqual(return_status, 0)
+        self.logger.info.assert_called_once_with("No galil directory present (configurations\\galil)")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes the crash described in https://github.com/ISISComputingGroup/IBEX/issues/2868 and makes it log a message if the galil directory was not present