### PR TITLE
Add step & tests to upgrade PIMOT macros

### DIFF
--- a/src/common_upgrades/config_filter.py
+++ b/src/common_upgrades/config_filter.py
@@ -5,6 +5,7 @@ import re
 CONFIG_FOLDER = os.path.join("configurations", "configurations")
 COMPONENT_FOLDER = os.path.join("configurations", "components")
 IOC_FILE = "iocs.xml"
+GLOBALS_FILENAME = os.path.join("configurations", "globals.txt")
 
 # Matches an ioc name and it's numbered IOC's e.g. GALIL matches GALIL_01, GALIL_02
 FILTER_REGEX = "^{}(_[\d]{{2}})?$"
@@ -16,6 +17,12 @@ class ConfigFilter():
     """
 
     def __init__(self, file_access, logger):
+        """
+        Initialise.
+        Args:
+            file_access: object to allow for file access
+            logger: Logger to use
+        """
         self._file_access = file_access
         self._logger = logger
 
@@ -57,3 +64,24 @@ class ConfigFilter():
                     xml_changed = True
             if xml_changed:
                 self._file_access.write_xml_file(path, ioc_xml)
+
+    def globals_filter_generator(self, ioc_to_change):
+        """
+        Generator that gives all the lines for a given IOC in globals.txt and saves them back to their original location
+        after they've been yielded. This will match IOCs with the same name as the root plus any that have a number
+        appended in the form _XX. To change the line change the yielded lines[index] to the value given.
+
+        Args:
+            ioc_to_change: the root name of the ioc to change
+        """
+
+        if self._file_access.exists(GLOBALS_FILENAME):
+            line_changed = False
+            lines = self._file_access.open_file(GLOBALS_FILENAME)
+            for index, line in enumerate(lines):
+                if line.startswith("{}_".format(ioc_to_change)):
+                    self._logger.info("Found line '{}' in {}".format(line, GLOBALS_FILENAME))
+                    line_changed = True
+                    yield index, lines
+            if line_changed:
+                self._file_access.write_file(GLOBALS_FILENAME, lines)

--- a/src/upgrade_step_from_4p3p1.py
+++ b/src/upgrade_step_from_4p3p1.py
@@ -47,6 +47,12 @@ class UpgradeStepFrom4p3p1(UpgradeStep):
             for ioc in config_filter.ioc_filter_generator("PIMOT"):
                 macros_xml = ioc.getElementsByTagName("macros")[0]
                 self._change_macros(macros_xml)
+
+            for line_index, iocs in config_filter.globals_filter_generator("PIMOT"):
+                match = re.match(r"(PIMOT_\d\d__[^=]*)1(.*)", iocs[line_index])
+                if match is not None:
+                    iocs[line_index] = match.group(1) + match.group(2)
+
         except Exception as e:
             logger.error("Changing PIMOT macros failed: {}".format(str(e)))
             return -1

--- a/src/upgrade_step_from_4p3p1.py
+++ b/src/upgrade_step_from_4p3p1.py
@@ -1,0 +1,53 @@
+from src.common_upgrades.config_filter import ConfigFilter
+from src.upgrade_step import UpgradeStep
+import re
+from xml.dom import minidom
+
+
+class UpgradeStepFrom4p3p1(UpgradeStep):
+    """
+    Change the PIMOT macros from BAUD1 and PORT1 to BAUD and PORT respectively.
+    """
+
+    def perform(self, file_access, logger):
+        """
+        Perform the upgrade step from version 0 to 1
+
+        Args:
+            file_access (FileAccess): file access
+            logger (LocalLogger): logger
+
+        Returns: exit code 0 success; anything else fail
+
+        """
+        return self.change_pimot_macros(file_access, logger)
+
+    @staticmethod
+    def _change_macros(macros_xml):
+        """
+        Changes the macros in the given xml.
+        Args:
+            macros_xml (NodeList): the current macros
+        """
+        for m in macros_xml.getElementsByTagName("macro"):
+            name = m.getAttribute("name")
+            if name.endswith("1"):
+                m.setAttribute("name", name[:-1])
+
+    def change_pimot_macros(self, file_access, logger):
+        """
+        Change the PIMOT macros from BAUD1 and PORT1 to BAUD and PORT respectively.
+
+        Args:
+            file_access (FileAccess): file access
+            logger (Logger): logger
+        """
+        config_filter = ConfigFilter(file_access, logger)
+        try:
+            for ioc in config_filter.ioc_filter_generator("PIMOT"):
+                macros_xml = ioc.getElementsByTagName("macros")[0]
+                self._change_macros(macros_xml)
+        except Exception as e:
+            logger.error("Changing PIMOT macros failed: {}".format(str(e)))
+            return -1
+        return 0

--- a/test/test_upgrade_step_from_4p3p1.py
+++ b/test/test_upgrade_step_from_4p3p1.py
@@ -1,0 +1,85 @@
+import unittest
+from hamcrest import *
+from mock import MagicMock as Mock
+import xml.etree.ElementTree as ET
+from src.upgrade_step_from_4p3p1 import UpgradeStepFrom4p3p1
+from mother import LoggingStub, FileAccessStub, create_xml_with_iocs
+
+NAMESPACE = "http://epics.isis.rl.ac.uk/schema/iocs/1.0"
+
+IOC_FILE_XML = """<?xml version="1.0" ?><iocs xmlns="{namespace}" xmlns:ioc="{namespace}" xmlns:xi="http://www.w3.org/2001/XInclude">
+    {{iocs}}
+</iocs>""".format(namespace=NAMESPACE)
+
+IOC_XML = """
+<ioc name="{name}">
+    <macros>
+        {macros}
+    </macros>
+    <pvs/>
+    <pvsets/>
+</ioc>
+"""
+
+MACRO_XML = """
+<macro name="{name}" value="{value}"/>
+"""
+
+
+def create_ioc(ioc_name, ioc_num, macros):
+    macro_xml = "".join([MACRO_XML.format(name=name, value=value) for name, value in macros.items()])
+    return IOC_XML.format(name="{}_{:0>2}".format(ioc_name, ioc_num), macros=macro_xml)
+
+
+class TestUpgradeStepFrom4p3p1(unittest.TestCase):
+
+    def setUp(self):
+        self.file_access = FileAccessStub()
+        self.upgrade_step = UpgradeStepFrom4p3p1()
+        self.logger = LoggingStub()
+
+    def _test_GIVEN_input_macros_when_macros_changed_THEN_new_macros_in_new_format(self, original_macros):
+
+        # Arrange
+        original_macros_with_values = dict()
+        for macro in original_macros:
+            original_macros_with_values[macro] = ""
+        xml = IOC_FILE_XML.format(iocs=create_ioc("PIMOT", 1, original_macros_with_values))
+        self.file_access.open_file = Mock(side_effect=[xml, "<a/>"])
+        self.file_access.is_dir = Mock(return_value=True)
+
+        # Act
+        self.upgrade_step.change_pimot_macros(self.file_access, self.logger)
+
+        # Assert
+        assert_that(self.file_access.write_file_contents, is_not(None))
+        written_xml = ET.fromstring(self.file_access.write_file_contents)
+        macro_names = [m.attrib["name"] for m in written_xml.findall(".//ns:macro", {"ns": NAMESPACE})]
+
+        assert_that(len(macro_names), is_(2))
+        assert_that(set(macro_names) == set(("PORT", "BAUD")))
+
+    def test_GIVEN_new_macro_format_WHEN_macros_changed_THEN_macros_unaffected(self):
+        self._test_GIVEN_input_macros_when_macros_changed_THEN_new_macros_in_new_format(("PORT", "BAUD"))
+
+    def test_GIVEN_both_macros_in_old_format_WHEN_macros_changed_THEN_both_macros_updated(self):
+        self._test_GIVEN_input_macros_when_macros_changed_THEN_new_macros_in_new_format(("PORT1", "BAUD1"))
+
+    def test_GIVEN_port_macro_in_old_format_WHEN_macros_changed_THEN_port_macro_updated(self):
+        self._test_GIVEN_input_macros_when_macros_changed_THEN_new_macros_in_new_format(("PORT1", "BAUD"))
+
+    def test_GIVEN_baud_macro_in_old_format_WHEN_macros_changed_THEN_baud_macro_updated(self):
+        self._test_GIVEN_input_macros_when_macros_changed_THEN_new_macros_in_new_format(("PORT", "BAUD1"))
+
+    def test_GIVEN_old_macro_format_on_not_PIMOT_ioc_WHEN_macros_changed_THEN_file_not_touched(self):
+        xml = IOC_FILE_XML.format(iocs=create_ioc("NOT_A_PIMOT", 1, {"PORT1": "", "BAUD1": ""}))
+        self.file_access.open_file = Mock(side_effect=[xml, "<a/>"])
+        self.file_access.is_dir = Mock(return_value=True)
+
+        self.upgrade_step.change_pimot_macros(self.file_access, self.logger)
+
+        assert_that(self.file_access.write_file_contents, is_(None))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/upgrade.py
+++ b/upgrade.py
@@ -8,6 +8,7 @@ from src.upgrade_step_from_3p2p1 import UpgradeStepFrom3p2p1
 from src.upgrade_step_from_3p2p1p1 import UpgradeStepFrom3p2p1p1
 from src.upgrade_step_from_3p2p1p2 import UpgradeStepFrom3p2p1p2
 from src.upgrade_step_from_4p1p0 import UpgradeStepFrom4p1p0
+from src.upgrade_step_from_4p3p1 import UpgradeStepFrom4p3p1
 from src.upgrade_step_noop import UpgradeStepNoOp
 
 # A list of upgrade step tuples tuple is name of version to apply the upgrade to and upgrade class.
@@ -24,7 +25,8 @@ UPGRADE_STEPS = [
     ("4.1.0.1", UpgradeStepNoOp()),
     ("4.2.0", UpgradeStepNoOp()),
     ("4.3.0", UpgradeStepNoOp()),
-    ("4.3.1", None)
+    ("4.3.1", UpgradeStepFrom4p3p1()),
+    ("4.4.0", UpgradeStepNoOp()),
 ]
 
 if __name__ == "__main__":

--- a/upgrade.py
+++ b/upgrade.py
@@ -26,7 +26,7 @@ UPGRADE_STEPS = [
     ("4.2.0", UpgradeStepNoOp()),
     ("4.3.0", UpgradeStepNoOp()),
     ("4.3.1", UpgradeStepFrom4p3p1()),
-    ("4.4.0", UpgradeStepNoOp()),
+    ("4.3.1.1", None)
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
Upgrade the PIMOT macros so it uses a non-indexed `PORT` and `BAUD` macro rather than `BAUD1` and `PORT1` in line with other motors.

https://github.com/ISISComputingGroup/IBEX/issues/3139