### PR TITLE
Added a script to automatically add new dbLoadRecordsLoop instructions

### DIFF
--- a/src/upgrade_step_from_5p0p1.py
+++ b/src/upgrade_step_from_5p0p1.py
@@ -1,0 +1,57 @@
+from src.common_upgrades.change_macro_in_globals import ChangeMacroInGlobals
+from src.common_upgrades.change_macros_in_xml import ChangeMacrosInXML
+import os
+
+from src.common_upgrades.utils.macro import Macro
+from src.upgrade_step import UpgradeStep
+
+
+class UpgradeStepFrom5p0p1(UpgradeStep):
+    ERROR_CODE = -1
+    SUCCESS_CODE = 0
+    LOAD_MOTION_SP_DB_INSTRUCTION = 'dbLoadRecords("$(MOTIONSETPOINTS)/db/motionSetPoints.db"'
+    LOAD_INPOS_DB_INSTRUCTION = 'dbLoadRecordsLoop("$(MOTIONSETPOINTS)/db/inPos.db"'
+
+    """
+    Change the PIMOT macros from BAUD1 and PORT1 to BAUD and PORT respectively.
+    """
+
+    def perform(self, file_access, logger):
+        """
+        Args:
+            file_access (FileAccess): file access
+            logger (LocalLogger): logger
+
+        Returns: exit code 0 success; anything else fail
+        """
+        motor_dirs = ["galil", "mclennan", "SM300_01"]
+
+        for motor in motor_dirs:
+            file_name = os.path.join("configurations", motor, "motionSetPoints.cmd")
+            if os.path.exists(file_name):
+                try:
+                    content = file_access.open_file(file_name)
+                    self.append_load_inpos_instructions(content)
+                    file_access.write_file(file_name, content)
+                except OSError:
+                    return self.ERROR_CODE
+
+        return self.SUCCESS_CODE
+
+    def append_load_inpos_instructions(self, content):
+        """
+        For each dbLoadRecord instruction loading a motionSetPoint.db read from the input file, add an equivalent line
+        to load the inPos.db with same macros.
+        Args:
+            file_access: The file access utility
+            content: The content of the motionSetPoint file
+        """
+        lines_to_add = []
+        for line in content:
+            if self.LOAD_MOTION_SP_DB_INSTRUCTION in line:
+                line = line.replace(self.LOAD_MOTION_SP_DB_INSTRUCTION, self.LOAD_INPOS_DB_INSTRUCTION)
+                line = line[:-1] + ',"I", 0, 10)'
+                lines_to_add.append(line)
+
+        for line in lines_to_add:
+            content.append(line)

--- a/src/upgrade_step_from_5p0p1.py
+++ b/src/upgrade_step_from_5p0p1.py
@@ -28,7 +28,7 @@ class UpgradeStepFrom5p0p1(UpgradeStep):
 
         for motor in motor_dirs:
             file_name = os.path.join("configurations", motor, "motionSetPoints.cmd")
-            if os.path.exists(file_name):
+            if file_access.exists(file_name):
                 try:
                     content = file_access.open_file(file_name)
                     self.append_load_inpos_instructions(content)
@@ -50,7 +50,7 @@ class UpgradeStepFrom5p0p1(UpgradeStep):
         for line in content:
             if self.LOAD_MOTION_SP_DB_INSTRUCTION in line:
                 line = line.replace(self.LOAD_MOTION_SP_DB_INSTRUCTION, self.LOAD_INPOS_DB_INSTRUCTION)
-                line = line[:-1] + ',"I", 0, 10)'
+                line = line[:-1] + ',"NUMPOS", 0, 30)'
                 lines_to_add.append(line)
 
         for line in lines_to_add:

--- a/test/test_upgrade_step_from_5p0p1.py
+++ b/test/test_upgrade_step_from_5p0p1.py
@@ -2,7 +2,7 @@ import unittest
 from src.upgrade_step_from_5p0p1 import UpgradeStepFrom5p0p1
 
 
-class TestUpgradeStepFrom4p3pXMLChanges(unittest.TestCase):
+class TestUpgradeStepFrom5p0p1Changes(unittest.TestCase):
 
     def setUp(self):
         self.upgrade_step = UpgradeStepFrom5p0p1()
@@ -39,7 +39,7 @@ class TestUpgradeStepFrom4p3pXMLChanges(unittest.TestCase):
         TEST_LKUP = "TEST_LKUP"
         setpoint_instruction = UpgradeStepFrom5p0p1.LOAD_MOTION_SP_DB_INSTRUCTION
         inpos_instruction = UpgradeStepFrom5p0p1.LOAD_INPOS_DB_INSTRUCTION
-        inpos_loop_suffix = '"I", 0, 10)'
+        inpos_loop_suffix = '"NUMPOS", 0, 30)'
         macros = '"P={pref},NAME1={name},AXIS1={axis},TOL={tol},LOOKUP={lkup}")'.format(
                 pref=TEST_PREFIX, name=TEST_NAME, axis=TEST_AXIS, tol=TEST_TOLERANCE, lkup=TEST_LKUP)
         dbload_instruction = setpoint_instruction + "," + macros + ")"
@@ -49,6 +49,7 @@ class TestUpgradeStepFrom4p3pXMLChanges(unittest.TestCase):
 
         expected = inpos_instruction + "," + macros + "," + inpos_loop_suffix
         self.assertEquals(expected, file_content[1])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_upgrade_step_from_5p0p1.py
+++ b/test/test_upgrade_step_from_5p0p1.py
@@ -1,0 +1,54 @@
+import unittest
+from src.upgrade_step_from_5p0p1 import UpgradeStepFrom5p0p1
+
+
+class TestUpgradeStepFrom4p3pXMLChanges(unittest.TestCase):
+
+    def setUp(self):
+        self.upgrade_step = UpgradeStepFrom5p0p1()
+
+    def test_GIVEN_blank_input_file_WHEN_adding_inpos_db_THEN_do_nothing(self):
+        expected = [""]
+        file_content = [""]
+
+        self.upgrade_step.append_load_inpos_instructions(file_content)
+
+        self.assertListEqual(expected, file_content)
+
+    def test_GIVEN_input_file_with_unrelated_lines_WHEN_modifying_content_THEN_no_lines_added(self):
+        file_content = ["some", "other", "lines"]
+        expected = len(file_content)
+
+        self.upgrade_step.append_load_inpos_instructions(file_content)
+
+        self.assertEquals(expected, len(file_content))
+
+    def test_GIVEN_input_file_with_dbloadrecord_lines_WHEN_modifying_content_THEN_equivalent_amount_of_lines_added(self):
+        file_content = ["some", UpgradeStepFrom5p0p1.LOAD_MOTION_SP_DB_INSTRUCTION + "1", "other", UpgradeStepFrom5p0p1.LOAD_MOTION_SP_DB_INSTRUCTION + "2", "lines"]
+        expected = len(file_content) + 2
+
+        self.upgrade_step.append_load_inpos_instructions(file_content)
+
+        self.assertEquals(expected, len(file_content))
+
+    def test_GIVEN_input_file_with_dbloadrecords_with_all_macros_set_WHEN_adding_inpos_db_THEN_dbloadrecordsloop_instruction_added_with_macros(self):
+        TEST_PREFIX = "TEST_PREFIX"
+        TEST_NAME = "TEST_NAME"
+        TEST_AXIS = "TEST_AXIS"
+        TEST_TOLERANCE = 0.1
+        TEST_LKUP = "TEST_LKUP"
+        setpoint_instruction = UpgradeStepFrom5p0p1.LOAD_MOTION_SP_DB_INSTRUCTION
+        inpos_instruction = UpgradeStepFrom5p0p1.LOAD_INPOS_DB_INSTRUCTION
+        inpos_loop_suffix = '"I", 0, 10)'
+        macros = '"P={pref},NAME1={name},AXIS1={axis},TOL={tol},LOOKUP={lkup}")'.format(
+                pref=TEST_PREFIX, name=TEST_NAME, axis=TEST_AXIS, tol=TEST_TOLERANCE, lkup=TEST_LKUP)
+        dbload_instruction = setpoint_instruction + "," + macros + ")"
+        file_content = [dbload_instruction]
+
+        self.upgrade_step.append_load_inpos_instructions(file_content)
+
+        expected = inpos_instruction + "," + macros + "," + inpos_loop_suffix
+        self.assertEquals(expected, file_content[1])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/upgrade.py
+++ b/upgrade.py
@@ -22,6 +22,7 @@ UPGRADE_STEPS = [
     ("4.4.1", UpgradeStepNoOp()),
     ("5.0.0", UpgradeStepNoOp()),
     ("5.0.1", UpgradeStepFrom5p0p1()),
+    ("5.1.0", None),
 ]
 
 if __name__ == "__main__":

--- a/upgrade.py
+++ b/upgrade.py
@@ -5,6 +5,7 @@ from src.file_access import FileAccess
 from src.local_logger import LocalLogger
 from src.upgrade import Upgrade
 from src.upgrade_step_from_4p3p1 import UpgradeStepFrom4p3p1
+from src.upgrade_step_from_5p0p1 import UpgradeStepFrom5p0p1
 from src.upgrade_step_noop import UpgradeStepNoOp
 
 # A list of upgrade step tuples tuple is name of version to apply the upgrade to and upgrade class.
@@ -20,7 +21,7 @@ UPGRADE_STEPS = [
     ("4.4.0", UpgradeStepNoOp()),
     ("4.4.1", UpgradeStepNoOp()),
     ("5.0.0", UpgradeStepNoOp()),
-    ("5.0.1", None),
+    ("5.0.1", UpgradeStepFrom5p0p1()),
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
Upgrade script for changes related to https://github.com/ISISComputingGroup/IBEX/issues/3577:

Adds an equivalent instruction to load the new `inPos.db` for each motion setpoint lookup file in the `motionSetPoints.cmd` in the motor config directories.