### PR TITLE
Changed IP address macro name

### DIFF
--- a/src/upgrade_step_change_moxa12XX_macros.py
+++ b/src/upgrade_step_change_moxa12XX_macros.py
@@ -1,0 +1,50 @@
+import traceback
+
+import six
+
+from src.common_upgrades.change_macro_in_globals import ChangeMacroInGlobals
+from src.common_upgrades.change_macros_in_xml import ChangeMacrosInXML
+
+from src.common_upgrades.utils.macro import Macro
+
+from src.upgrade_step import UpgradeStep
+
+
+class UpgradeMOXA12XXMacros(UpgradeStep):
+    """
+    Renames the moxa1210 IOC to the more general moxa12xx
+    """
+
+    def perform(self, file_access, logger):
+        """
+        Change ioc name MOXA1210 TO MOXA12XX. Remove leading zeroes in channel name macros
+
+        Args:
+            file_access (FileAccess): file access
+            logger (Logger): logger
+        """
+        ioc_name = "MOXA12XX"
+
+        macros_to_change = [
+            (Macro("IP_ADDR"), Macro("ADDR")),
+        ]
+
+        try:
+            change_xml_macros = ChangeMacrosInXML(file_access, logger)
+
+            change_xml_macros.change_macros(ioc_name, macros_to_change)
+
+        except Exception as e:
+            logger.error("Changing MOXA12XX Macro failed: {}".format(str(e)))
+            traceback.print_exc()
+            return -1
+
+        try:
+            change_global_macros = ChangeMacroInGlobals(file_access, logger)
+
+            change_global_macros.change_macros(ioc_name, macros_to_change)
+
+        except Exception as e:
+            logger.error("Changing MOXA12XX Macro failed: {}".format(str(e)))
+            traceback.print_exc()
+            return -1

--- a/upgrade.py
+++ b/upgrade.py
@@ -9,6 +9,7 @@ from src.upgrade_step_from_4p3p1 import UpgradeStepFrom4p3p1
 from src.upgrade_step_from_5p0p1 import UpgradeMotionSetpoints, UpgradeExpDatabase
 from src.upgrade_step_from_5p1p0 import RemoveOldExpPopulator
 from src.upgrade_step_rename_moxa1210 import UpgradeMOXA1210IOCs
+from src.upgrade_step_change_moxa12XX_macros import UpgradeMOXA12XXMacros
 from src.upgrade_step_noop import UpgradeStepNoOp
 
 # A list of upgrade step tuples tuple is name of version to apply the upgrade to and upgrade class.
@@ -30,6 +31,7 @@ UPGRADE_STEPS = [
     ("5.1.0.1", UpgradeArchiveUseMediumBlob()),
     ("5.1.0.2", UpgradeStepNoOp()),
     ("5.1.1", UpgradeMOXA1210IOCs()),  # should have been 5.1.0.3 but we cant change it now
+    ("5.1.1.1", UpgradeMOXA12XXMacros()),
     ("5.2.0", None)
     # to add step see https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Config-Upgrader#adding-an-upgrade-step
 ]


### PR DESCRIPTION
## Description of work

Adds a step to ensure moxa e12XX devices follow macro naming conventions

## To test

https://github.com/ISISComputingGroup/IBEX/issues/3969