### PR TITLE
Add dashboard PVs to config area

### DIFF
--- a/data/dashboard.db
+++ b/data/dashboard.db
@@ -1,0 +1,131 @@
+record(scalcout, "$(P)CS:DASHBOARD:BANNER:LEFT:_CALC") {
+    field(INPA, "$(P)DAE:RUNSTATE CP MS")
+    field(BB, "Run:")
+    field(CC, "Next run:")
+    field(CALC, "(A=2||A=3||A=4||A=5)?BB:CC")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:LEFT:LABEL") {
+    field(INP, "$(P)CS:DASHBOARD:BANNER:LEFT:_CALC.SVAL CP MS")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:LEFT:VALUE") {
+    field(INP, "$(P)DAE:RUNNUMBER CP MS")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:MIDDLE:LABEL") {
+    field(VAL, "")
+    field(PINI, "YES")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:MIDDLE:VALUE") {
+    field(VAL, "")
+    field(PINI, "YES")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:RIGHT:LABEL") {
+    field(VAL, "Shutter:")
+    field(PINI, "YES")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:RIGHT:VALUE") {
+    field(INP, "$(P)SHTR:STAT CP MS")
+}
+
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:1:1:LABEL") {
+    field(VAL, "Good / Raw Frames:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:1:1:_CALC") {
+    field(INAA, "$(P)DAE:GOODFRAMES CP MS")
+    field(BB, " / ")
+    field(INCC, "$(P)DAE:RAWFRAMES CP MS")
+    field(CALC, "PRINTF('%d', AA)+STR(BB)+PRINTF('%d', CC)")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:1:1:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:1:1:_CALC.SVAL CP MS")
+}
+
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:2:1:LABEL") {
+    field(VAL, "Current / Total:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:2:1:_CALC") {
+    field(INAA, "$(P)DAE:BEAMCURRENT CP MS")
+    field(BB, " / ")
+    field(INCC, "$(P)DAE:GOODUAH CP MS")
+    field(CALC, "PRINTF('%.3f', AA)+STR(BB)+PRINTF('%d', CC)")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:2:1:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:2:1:_CALC.SVAL CP MS")
+}
+
+
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:3:1:LABEL") {
+    field(VAL, "Monitor Counts:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:3:1:_CALC") {
+    field(INAA, "$(P)DAE:COUNTRATE CP MS")
+    field(CALC, "PRINTF('%d', AA)")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:3:1:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:3:1:_CALC.SVAL CP MS")
+}
+
+
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:1:2:LABEL") {
+    field(VAL, "Inst. Time:")
+    field(PINI, "YES")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:1:2:VALUE") {
+    field(INP, "$(P)CS:IOC:INSTETC_01:DEVIOS:TOD CP MS")
+}
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:2:2:LABEL") {
+    field(VAL, "Run Time:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:2:2:_CALC") {
+    field(INAA, "$(P)DAE:RUNDURATION CP MS")
+    field(BB, " s")
+    field(CALC, "PRINTF('%d', AA)+BB")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:2:2:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:2:2:_CALC.SVAL CP MS")
+}
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:3:2:LABEL") {
+    field(VAL, "Period:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:3:2:_CALC") {
+    field(INAA, "$(P)DAE:PERIOD CP MS")
+    field(BB, " / ")
+    field(INCC, "$(P)DAE:NUMPERIODS CP MS")
+    field(CALC, "PRINTF('%d', AA)+BB+PRINTF('%d', CC)")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:3:2:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:3:2:_CALC.SVAL CP MS")
+}

--- a/data/dashboard.db
+++ b/data/dashboard.db
@@ -13,14 +13,26 @@ record(stringin, "$(P)CS:DASHBOARD:BANNER:LEFT:VALUE") {
     field(INP, "$(P)DAE:RUNNUMBER CP MS")
 }
 
+record(scalcout, "$(P)CS:DASHBOARD:BANNER:MIDDLE:_LCAL") {
+    field(INPA, "$(P)DAE:SIM_MODE CP MS")
+    field(BB, "Simulated")
+    field(CC, "")
+    field(CALC, "(A=1)?BB:CC")
+}
+
 record(stringin, "$(P)CS:DASHBOARD:BANNER:MIDDLE:LABEL") {
-    field(VAL, "")
-    field(PINI, "YES")
+    field(INP, "$(P)CS:DASHBOARD:BANNER:MIDDLE:_LCAL.SVAL CP MS")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:BANNER:MIDDLE:_VCAL") {
+    field(INPA, "$(P)DAE:SIM_MODE CP MS")
+    field(BB, "DAE")
+    field(CC, "")
+    field(CALC, "(A=1)?BB:CC")
 }
 
 record(stringin, "$(P)CS:DASHBOARD:BANNER:MIDDLE:VALUE") {
-    field(VAL, "")
-    field(PINI, "YES")
+    field(INP, "$(P)CS:DASHBOARD:BANNER:MIDDLE:_VCAL.SVAL CP MS")
 }
 
 record(stringin, "$(P)CS:DASHBOARD:BANNER:RIGHT:LABEL") {

--- a/data/dashboard_muon.db
+++ b/data/dashboard_muon.db
@@ -13,14 +13,26 @@ record(stringin, "$(P)CS:DASHBOARD:BANNER:LEFT:VALUE") {
     field(INP, "$(P)DAE:RUNNUMBER CP MS")
 }
 
+record(scalcout, "$(P)CS:DASHBOARD:BANNER:MIDDLE:_LCAL") {
+    field(INPA, "$(P)DAE:SIM_MODE CP MS")
+    field(BB, "Simulated")
+    field(CC, "")
+    field(CALC, "(A=1)?BB:CC")
+}
+
 record(stringin, "$(P)CS:DASHBOARD:BANNER:MIDDLE:LABEL") {
-    field(VAL, "")
-    field(PINI, "YES")
+    field(INP, "$(P)CS:DASHBOARD:BANNER:MIDDLE:_LCAL.SVAL CP MS")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:BANNER:MIDDLE:_VCAL") {
+    field(INPA, "$(P)DAE:SIM_MODE CP MS")
+    field(BB, "DAE")
+    field(CC, "")
+    field(CALC, "(A=1)?BB:CC")
 }
 
 record(stringin, "$(P)CS:DASHBOARD:BANNER:MIDDLE:VALUE") {
-    field(VAL, "")
-    field(PINI, "YES")
+    field(INP, "$(P)CS:DASHBOARD:BANNER:MIDDLE:_VCAL.SVAL CP MS")
 }
 
 record(stringin, "$(P)CS:DASHBOARD:BANNER:RIGHT:LABEL") {

--- a/data/dashboard_muon.db
+++ b/data/dashboard_muon.db
@@ -1,0 +1,135 @@
+record(scalcout, "$(P)CS:DASHBOARD:BANNER:LEFT:_CALC") {
+    field(INPA, "$(P)DAE:RUNSTATE CP MS")
+    field(BB, "Run:")
+    field(CC, "Next run:")
+    field(CALC, "(A=2||A=3||A=4||A=5)?BB:CC")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:LEFT:LABEL") {
+    field(INP, "$(P)CS:DASHBOARD:BANNER:LEFT:_CALC.SVAL CP MS")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:LEFT:VALUE") {
+    field(INP, "$(P)DAE:RUNNUMBER CP MS")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:MIDDLE:LABEL") {
+    field(VAL, "")
+    field(PINI, "YES")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:MIDDLE:VALUE") {
+    field(VAL, "")
+    field(PINI, "YES")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:RIGHT:LABEL") {
+    field(VAL, "Kicker:")
+    field(PINI, "YES")
+}
+
+record(bi, "$(P)CS:DASHBOARD:BANNER:RIGHT:_CALC") {
+    field(INP, "BL:MUON:KICKR CP MS")
+    field(ZNAM, "Off")
+    field(ONAM, "On")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:BANNER:RIGHT:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:BANNER:RIGHT:_CALC CP MS")
+}
+
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:1:1:LABEL") {
+    field(VAL, "Good / Raw Frames:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:1:1:_CALC") {
+    field(INAA, "$(P)DAE:GOODFRAMES CP MS")
+    field(BB, " / ")
+    field(INCC, "$(P)DAE:RAWFRAMES CP MS")
+    field(CALC, "PRINTF('%d', AA)+STR(BB)+PRINTF('%d', CC)")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:1:1:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:1:1:_CALC.SVAL CP MS")
+}
+
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:2:1:LABEL") {
+    field(VAL, "MEvents:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:2:1:_CALC") {
+    field(INAA, "$(P)DAE:MEVENTS CP MS")
+    field(CALC, "PRINTF('%.4f', AA)")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:2:1:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:2:1:_CALC.SVAL CP MS")
+}
+
+
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:3:1:LABEL") {
+    field(VAL, "Count Rate:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:3:1:_CALC") {
+    field(INAA, "$(P)DAE:COUNTRATE CP MS")
+    field(CALC, "PRINTF('%4f', AA)")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:3:1:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:3:1:_CALC.SVAL CP MS")
+}
+
+
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:1:2:LABEL") {
+    field(VAL, "Inst. Time:")
+    field(PINI, "YES")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:1:2:VALUE") {
+    field(INP, "$(P)CS:IOC:INSTETC_01:DEVIOS:TOD CP MS")
+}
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:2:2:LABEL") {
+    field(VAL, "Run Time:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:2:2:_CALC") {
+    field(INAA, "$(P)DAE:RUNDURATION CP MS")
+    field(BB, " s")
+    field(CALC, "PRINTF('%d', AA)+BB")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:2:2:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:2:2:_CALC.SVAL CP MS")
+}
+
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:3:2:LABEL") {
+    field(VAL, "Period:")
+    field(PINI, "YES")
+}
+
+record(scalcout, "$(P)CS:DASHBOARD:TAB:3:2:_CALC") {
+    field(INAA, "$(P)DAE:PERIOD CP MS")
+    field(BB, " / ")
+    field(INCC, "$(P)DAE:NUMPERIODS CP MS")
+    field(CALC, "PRINTF('%d', AA)+BB+PRINTF('%d', CC)")
+}
+
+record(stringin, "$(P)CS:DASHBOARD:TAB:3:2:VALUE") {
+    field(INP, "$(P)CS:DASHBOARD:TAB:3:2:_CALC.SVAL CP MS")
+}

--- a/src/upgrade_step_from_5p6p0.py
+++ b/src/upgrade_step_from_5p6p0.py
@@ -1,3 +1,5 @@
+import shutil
+
 from src.upgrade_step import UpgradeStep
 
 
@@ -37,4 +39,19 @@ class ChangeConfigurationSchema(UpgradeStep):
 
                 et.write(filename)
 
+        return 0
+
+
+class CopyDashboardDatabase(UpgradeStep):
+    """
+    Step that changes the PVs associated with the jawsmanager as they have been renamed.
+    """
+
+    def perform(self, file_access, logger):
+        dashboard_db_path = os.path.join(os.environ["ICPCONFIGROOT"], "dashboard.db")
+        if not os.path.exists(dashboard_db_path):
+            shutil.copyfile(os.path.join(os.path.basename(os.path.abspath(__file__)), "..", "data", "dashboard.db"),
+                            dashboard_db_path)
+        else:
+            print("Not copying dashboard DB to '{}' as it already exists".format(dashboard_db_path))
         return 0

--- a/src/upgrade_step_from_5p6p0.py
+++ b/src/upgrade_step_from_5p6p0.py
@@ -38,7 +38,6 @@ class ChangeConfigurationSchema(UpgradeStep):
                     ioc.attrib["remotePvPrefix"] = ""
 
                 et.write(filename)
-
         return 0
 
 

--- a/upgrade.py
+++ b/upgrade.py
@@ -9,7 +9,7 @@ from src.upgrade_step_from_4p3p1 import UpgradeStepFrom4p3p1
 from src.upgrade_step_from_5p0p1 import UpgradeMotionSetpoints, UpgradeExpDatabase
 from src.upgrade_step_from_5p1p0 import RemoveOldExpPopulator
 from src.upgrade_step_from_5p4p1 import UpgradeBannerXml
-from src.upgrade_step_from_5p6p0 import ChangeConfigurationSchema
+from src.upgrade_step_from_5p6p0 import ChangeConfigurationSchema, CopyDashboardDatabase
 from src.upgrade_step_ITC_PVs import ChangeITCPVs
 from src.upgrade_step_rename_moxa1210 import UpgradeMOXA1210IOCs
 from src.upgrade_step_change_moxa12XX_macros import UpgradeMOXA12XXMacros
@@ -48,7 +48,8 @@ UPGRADE_STEPS = [
     ("5.6.0.1", ChangeConfigurationSchema()),
     ("5.6.0.2", UpgradeBannerXml()),
     ("5.6.0.3", UpgradeStepCheckInitInst()),
-    ("5.6.0.4", None)
+    ("5.6.0.4", CopyDashboardDatabase()),
+    ("5.6.0.5", None),
 
     # to add step see https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Config-Upgrader#adding-an-upgrade-step
 ]


### PR DESCRIPTION
Copy dashboard DB into config area on upgrade.

The default DB included in this PR is appropriate for a neutron instrument - it should look nearly identical to what they currently have. 

Testing the DB included with this pull request using the IOC test framework would be ideal, however it is tightly coupled to the DAE, and the DAE has no emulation, meaning that it is very difficult to test.