### PR TITLE
Rename synoptic PVs on upgrade

### DIFF
--- a/test/mother.py
+++ b/test/mother.py
@@ -68,7 +68,7 @@ class FileAccessStub(object):
         yield type, self.open_xml_file(type)
 
     def get_synoptic_files(self):
-        yield [("", self.open_xml_file(""))]
+        yield "", self.open_xml_file("")
 
 def create_xml_with_iocs(iocs):
     """

--- a/test/mother.py
+++ b/test/mother.py
@@ -67,6 +67,8 @@ class FileAccessStub(object):
     def get_config_files(self, type):
         yield type, self.open_xml_file(type)
 
+    def get_synoptic_files(self):
+        yield [("", self.open_xml_file(""))]
 
 def create_xml_with_iocs(iocs):
     """

--- a/test/test_xml_pv_changer.py
+++ b/test/test_xml_pv_changer.py
@@ -5,12 +5,12 @@ from test.mother import LoggingStub, FileAccessStub
 from mock import MagicMock as Mock
 
 
-NAMESPACE = "http://epics.isis.rl.ac.uk/schema/blocks/1.0"
+BLOCK_NAMESPACE = "http://epics.isis.rl.ac.uk/schema/blocks/1.0"
 
 
 BLOCK_FILE_XML = """<?xml version="1.0" ?><blocks xmlns="{namespace}" xmlns:blk="{namespace}" xmlns:xi="http://www.w3.org/2001/XInclude">
     {{blocks}}
-</blocks>""".format(namespace=NAMESPACE)
+</blocks>""".format(namespace=BLOCK_NAMESPACE)
 
 
 BLOCK_XML = """
@@ -21,9 +21,38 @@ BLOCK_XML = """
 """
 
 
-def create_block_xml(block_dict):
-    block_xml = "".join([BLOCK_XML.format(name=block[0], pv=block[1]) for block in block_dict])
-    return BLOCK_FILE_XML.format(blocks=block_xml)
+SYNOPTIC_NAMESPACE = "http://www.isis.stfc.ac.uk//instrument"
+
+
+SYNOPTIC_FILE_XML = """<?xml version="1.0" ?><instrument xmlns="{namespace}">
+    <name>TEST</name>
+    <components>
+        <component>
+            <name>COMPONENT_NAME</name>
+            <type>UNKNOWN</type>
+            <target/>
+            <pvs>
+                {{blocks}}
+            </pvs>
+        </component>
+    </components>
+</instrument>""".format(namespace=SYNOPTIC_NAMESPACE)
+
+
+SYNOPTIC_XML = """
+<pv>
+    <displayname>{name}</displayname>
+    <address>{pv}</address>
+    <recordtype>
+        <io>READ</io>
+    </recordtype>
+</pv>
+"""
+
+
+def create_pv_xml(file_xml, pv_xml, pv_dict):
+    block_xml = "".join([pv_xml.format(name=pv[0], pv=pv[1]) for pv in pv_dict])
+    return file_xml.format(blocks=block_xml)
 
 
 class TestChangePVs(unittest.TestCase):
@@ -32,35 +61,52 @@ class TestChangePVs(unittest.TestCase):
         self.logger = LoggingStub()
         self.pv_changer = ChangePVsInXML(self.file_access, self.logger)
 
+    def _test_changing_pv(self, starting_blocks, pv_to_change, new_pv, expected_blocks):
+        self._test_changing_blocks(starting_blocks, pv_to_change, new_pv, expected_blocks)
+        self._test_changing_synoptics(starting_blocks, pv_to_change, new_pv, expected_blocks)
+
     def _test_changing_blocks(self, starting_blocks, pv_to_change, new_pv, expected_blocks):
         # Given:
-        self.file_access.open_file = Mock(return_value=create_block_xml(starting_blocks))
+        self.file_access.open_file = Mock(return_value=create_pv_xml(BLOCK_FILE_XML, BLOCK_XML, starting_blocks))
         self.file_access.write_file = Mock()
         self.file_access.get_config_files = Mock(return_value=[("file1.xml", self.file_access.open_xml_file(None))])
 
         # When:
-        self.pv_changer.change_pv_name(pv_to_change, new_pv)
+        self.pv_changer.change_pv_name_in_blocks(pv_to_change, new_pv)
 
         # Then:
-        expected_block_xml = create_block_xml(expected_blocks)
-        assert_that(self.file_access.write_file_contents, is_(expected_block_xml))
+        expected_xml = create_pv_xml(BLOCK_FILE_XML, BLOCK_XML, expected_blocks)
+        assert_that(self.file_access.write_file_contents, is_(expected_xml))
+
+    def _test_changing_synoptics(self, starting_blocks, pv_to_change, new_pv, expected_blocks):
+        # Given:
+        self.file_access.open_file = Mock(return_value=create_pv_xml(SYNOPTIC_FILE_XML, SYNOPTIC_XML, starting_blocks))
+        self.file_access.write_file = Mock()
+        self.file_access.get_synoptic_files = Mock(return_value=[("file1.xml", self.file_access.open_xml_file(None))])
+
+        # When:
+        self.pv_changer.change_pv_names_in_synoptics(pv_to_change, new_pv)
+
+        # Then:
+        expected_xml = create_pv_xml(SYNOPTIC_FILE_XML, SYNOPTIC_XML, expected_blocks)
+        assert_that(self.file_access.write_file_contents, is_(expected_xml))
 
     def test_GIVEN_multiple_different_blocks_in_configuration_WHEN_ones_pv_is_changed_THEN_only_that_block_changes(self):
-        self._test_changing_blocks([("BLOCKNAME", "BLOCK_PV"), ("BLOCKNAME_2", "CHANGEME")], "CHANGEME", "CHANGED",
-                                   [("BLOCKNAME", "BLOCK_PV"), ("BLOCKNAME_2", "CHANGED")])
+        self._test_changing_pv([("BLOCKNAME", "BLOCK_PV"), ("BLOCKNAME_2", "CHANGEME")], "CHANGEME", "CHANGED",
+                               [("BLOCKNAME", "BLOCK_PV"), ("BLOCKNAME_2", "CHANGED")])
 
     def test_GIVEN_block_with_part_of_PV_WHEN_pv_is_changed_THEN_only_part_of_PV_changes(self):
-        self._test_changing_blocks([("BLOCKNAME", "CHANGEME:BUT:NOT:ME")], "CHANGEME", "CHANGED",
-                                   [("BLOCKNAME", "CHANGED:BUT:NOT:ME")])
+        self._test_changing_pv([("BLOCKNAME", "CHANGEME:BUT:NOT:ME")], "CHANGEME", "CHANGED",
+                               [("BLOCKNAME", "CHANGED:BUT:NOT:ME")])
 
     def test_GIVEN_two_blocks_that_need_changing_WHEN_pv_is_changed_THEN_both_change(self):
-        self._test_changing_blocks([("BLOCKNAME", "CHANGEME:BUT:NOT:ME"), ("BLOCKNAME_1", "ALSO:CHANGEME:BUT:NOT:ME")],
-                                   "CHANGEME", "CHANGED",
-                                   [("BLOCKNAME", "CHANGED:BUT:NOT:ME"), ("BLOCKNAME_1", "ALSO:CHANGED:BUT:NOT:ME")])
+        self._test_changing_pv([("BLOCKNAME", "CHANGEME:BUT:NOT:ME"), ("BLOCKNAME_1", "ALSO:CHANGEME:BUT:NOT:ME")],
+                               "CHANGEME", "CHANGED",
+                               [("BLOCKNAME", "CHANGED:BUT:NOT:ME"), ("BLOCKNAME_1", "ALSO:CHANGED:BUT:NOT:ME")])
 
     def test_GIVEN_block_with_name_that_could_be_changed_WHEN_pv_is_changed_THEN_name_is_not(self):
-        self._test_changing_blocks([("CHANGEME", "BLAH")], "CHANGEME", "CHANGED",
-                                   [("CHANGEME", "BLAH")])
+        self._test_changing_pv([("CHANGEME", "BLAH")], "CHANGEME", "CHANGED",
+                               [("CHANGEME", "BLAH")])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description of work
Adds a step in the PV changing method to rename any references to the PV in all synoptic config files. For ease of testing, there are separate functions for renaming PVs in the blocks and synoptic configs.

The unit tests have been updated to check that PVs are renamed in both types of config.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/5275

### Acceptance criteria
- All tests pass