### PR TITLE
Add step to set DISABLE_AUTOONOFF macro to true on DFKPS IOCs on EMU

### DIFF
--- a/src/common_upgrades/change_macros_in_xml.py
+++ b/src/common_upgrades/change_macros_in_xml.py
@@ -1,5 +1,4 @@
 import re
-import xml.dom
 from xml.parsers.expat import ExpatError
 
 from src.common_upgrades.utils.constants import FILTER_REGEX, IOC_FILE, SYNOPTIC_FOLDER
@@ -44,7 +43,7 @@ def find_macro_with_name(macros, name_to_find):
         macros: XML element containing list of macros
         name: Name of macro to find
     Returns:
-        True or False
+        True if macro was found
     """
     for macro in macros.getElementsByTagName("macro"):
         if macro.getAttribute("name") == name_to_find:
@@ -84,19 +83,18 @@ class ChangeMacrosInXML(object):
         for path, ioc_xml in self._file_access.get_config_files(IOC_FILE):
             for ioc in self.ioc_tag_generator(path, ioc_xml, ioc_name):
                 macros = ioc.getElementsByTagName("macros")[0]
-                if find_macro_with_name(macros, macro_to_add.name):
-                    break
-                new_macro = ioc_xml.createElement("macro")
-                new_macro.setAttribute("name", macro_to_add.name)
-                new_macro.setAttribute("value", macro_to_add.value)
-                new_macro.setAttribute("pattern", pattern)
-                new_macro.setAttribute("description", description)
-                if default_value:
-                    new_macro.setAttribute("hasDefault", "yes")
-                    new_macro.setAttribute("defaultValue", default_value)
-                else:
-                    new_macro.setAttribute("hasDefault", "no")
-                macros.appendChild(new_macro)
+                if not find_macro_with_name(macros, macro_to_add.name):
+                    new_macro = ioc_xml.createElement("macro")
+                    new_macro.setAttribute("name", macro_to_add.name)
+                    new_macro.setAttribute("value", macro_to_add.value)
+                    new_macro.setAttribute("pattern", pattern)
+                    new_macro.setAttribute("description", description)
+                    if default_value is not None:
+                        new_macro.setAttribute("hasDefault", "yes")
+                        new_macro.setAttribute("defaultValue", default_value)
+                    else:
+                        new_macro.setAttribute("hasDefault", "no")
+                    macros.appendChild(new_macro)
 
             self._file_access.write_xml_file(path, ioc_xml)
 

--- a/src/common_upgrades/change_macros_in_xml.py
+++ b/src/common_upgrades/change_macros_in_xml.py
@@ -87,13 +87,7 @@ class ChangeMacrosInXML(object):
                     new_macro = ioc_xml.createElement("macro")
                     new_macro.setAttribute("name", macro_to_add.name)
                     new_macro.setAttribute("value", macro_to_add.value)
-                    new_macro.setAttribute("pattern", pattern)
-                    new_macro.setAttribute("description", description)
-                    if default_value is not None:
-                        new_macro.setAttribute("hasDefault", "yes")
-                        new_macro.setAttribute("defaultValue", default_value)
-                    else:
-                        new_macro.setAttribute("hasDefault", "no")
+
                     macros.appendChild(new_macro)
 
             self._file_access.write_xml_file(path, ioc_xml)

--- a/src/common_upgrades/change_macros_in_xml.py
+++ b/src/common_upgrades/change_macros_in_xml.py
@@ -3,8 +3,6 @@ from xml.parsers.expat import ExpatError
 
 from src.common_upgrades.utils.constants import FILTER_REGEX, IOC_FILE, SYNOPTIC_FOLDER
 
-#TEMPORARY!!!!!!!!!!!!
-import xml.dom.minidom
 
 def change_macro_name(macro, old_macro_name, new_macro_name):
     """
@@ -67,34 +65,14 @@ class ChangeMacrosInXML(object):
             for ioc in self.ioc_tag_generator(path, ioc_xml, ioc_name):
                 macros = ioc.getElementsByTagName("macros")[0]
                 for macro in macros.getElementsByTagName("macro"):
+                    name = macro.getAttribute("name")
                     for old_macro, new_macro in macros_to_change:
-                        change_macro_name(macro, old_macro.name, new_macro.name)
-                        change_macro_value(macro, old_macro.value, new_macro.value)
+                        #Check if current macro name starts with name of macro to be changed
+                        if re.match(old_macro.name, name) is not None:
+                            change_macro_name(macro, old_macro.name, new_macro.name)
+                            change_macro_value(macro, old_macro.value, new_macro.value)
 
             self._file_access.write_xml_file(path, ioc_xml)
-            
-    def change_specific_macros(self, ioc_name, macro_to_change):
-        """
-        Finds all iocs in config with the name ioc_name, then gets the macro with name
-        macro_to_change.name and changes its value to macro_to_change.value. Differs from
-        change_macros in that it will only change the value of the one macro specified.
-        
-        Args:
-            ioc_name: Name of the IOC to change macros within.
-            macro_to_change: Macro object with name attribute equal to name of macro to change
-            and value attribute equal to desired new value.
-        Returns:
-            None.
-        """
-    
-        for path, ioc_xml in self._file_access.get_config_files(IOC_FILE):
-            for ioc in self.ioc_tag_generator(path, ioc_xml, ioc_name):
-                macros = ioc.getElementsByTagName("macros")[0]
-                for macro in macros.getElementsByTagName("macro"):
-                    if macro.getAttribute("name") == macro_to_change.name:
-                        macro.setAttribute("value", macro_to_change.value)
-
-            self._file_access.write_xml_file(path, ioc_xml)    
 
     def change_ioc_name(self, old_ioc_name, new_ioc_name):
         """

--- a/src/common_upgrades/change_macros_in_xml.py
+++ b/src/common_upgrades/change_macros_in_xml.py
@@ -3,6 +3,8 @@ from xml.parsers.expat import ExpatError
 
 from src.common_upgrades.utils.constants import FILTER_REGEX, IOC_FILE, SYNOPTIC_FOLDER
 
+#TEMPORARY!!!!!!!!!!!!
+import xml.dom.minidom
 
 def change_macro_name(macro, old_macro_name, new_macro_name):
     """
@@ -61,7 +63,6 @@ class ChangeMacrosInXML(object):
         Returns:
             None.
         """
-
         for path, ioc_xml in self._file_access.get_config_files(IOC_FILE):
             for ioc in self.ioc_tag_generator(path, ioc_xml, ioc_name):
                 macros = ioc.getElementsByTagName("macros")[0]
@@ -71,6 +72,29 @@ class ChangeMacrosInXML(object):
                         change_macro_value(macro, old_macro.value, new_macro.value)
 
             self._file_access.write_xml_file(path, ioc_xml)
+            
+    def change_specific_macros(self, ioc_name, macro_to_change):
+        """
+        Finds all iocs in config with the name ioc_name, then gets the macro with name
+        macro_to_change.name and changes its value to macro_to_change.value. Differs from
+        change_macros in that it will only change the value of the one macro specified.
+        
+        Args:
+            ioc_name: Name of the IOC to change macros within.
+            macro_to_change: Macro object with name attribute equal to name of macro to change
+            and value attribute equal to desired new value.
+        Returns:
+            None.
+        """
+    
+        for path, ioc_xml in self._file_access.get_config_files(IOC_FILE):
+            for ioc in self.ioc_tag_generator(path, ioc_xml, ioc_name):
+                macros = ioc.getElementsByTagName("macros")[0]
+                for macro in macros.getElementsByTagName("macro"):
+                    if macro.getAttribute("name") == macro_to_change.name:
+                        macro.setAttribute("value", macro_to_change.value)
+
+            self._file_access.write_xml_file(path, ioc_xml)    
 
     def change_ioc_name(self, old_ioc_name, new_ioc_name):
         """

--- a/src/upgrade_step_from_6p0p0.py
+++ b/src/upgrade_step_from_6p0p0.py
@@ -6,7 +6,7 @@ from src.upgrade_step import UpgradeStep
 
 class SetDanfysikDisableAutoonoffMacros(UpgradeStep):
     """
-    Set the ALLOW_AUTO_ONOFF macro to true for EMU. When this macro is true, 
+    Set the DISABLE_AUTONOFF macro to true for EMU or add it if not present. When this macro is true,
     settings will be displayed on the Danfysik OPI allowing automatic power turn on/off.
     """
     def perform(self, file_access, logger):
@@ -15,8 +15,9 @@ class SetDanfysikDisableAutoonoffMacros(UpgradeStep):
             ioc_name = "DFKPS"
             if hostname=="NDXEMU":
                 change_macros_in_xml = ChangeMacrosInXML(file_access, logger)
+                change_macros_in_xml.add_macro(ioc_name, Macro("DISABLE_AUTOONOFF", "0"), "^(0|1)$", "Disable automatic PSU on/off feature", "1")
                 change_macros_in_xml.change_macros(ioc_name, [(Macro("DISABLE_AUTOONOFF"), Macro("DISABLE_AUTOONOFF", "0"))])
-                return 0
+            return 0
         except Exception as e:
             logger.error("Unable to perform upgrade, caught error: {}".format(e))
             return 1

--- a/src/upgrade_step_from_6p0p0.py
+++ b/src/upgrade_step_from_6p0p0.py
@@ -1,0 +1,22 @@
+import socket
+
+from src.common_upgrades.change_macros_in_xml import ChangeMacrosInXML
+from src.common_upgrades.utils.macro import Macro
+from src.upgrade_step import UpgradeStep
+
+class SetDanfysikDisableAutoonoffMacros(UpgradeStep):
+    """
+    Set the ALLOW_AUTO_ONOFF macro to true for EMU. When this macro is true, 
+    settings will be displayed on the Danfysik OPI allowing automatic power turn on/off.
+    """
+    def perform(self, file_access, logger):
+        try:
+            hostname = socket.gethostname()
+            ioc_name = "DFKPS"
+            if hostname=="NDXEMU":
+                macro_to_change = Macro("DISABLE_AUTOONOFF", "0")
+                change_macros_in_xml = ChangeMacrosInXML(file_access, logger)
+                change_macros_in_xml.change_specific_macros(ioc_name, macro_to_change)
+            return 0
+        except:
+            return 1

--- a/src/upgrade_step_from_6p0p0.py
+++ b/src/upgrade_step_from_6p0p0.py
@@ -13,7 +13,7 @@ class SetDanfysikDisableAutoonoffMacros(UpgradeStep):
         try:
             hostname = socket.gethostname()
             ioc_name = "DFKPS"
-            if hostname=="NDXEMU":
+            if hostname == "NDXEMU":
                 change_macros_in_xml = ChangeMacrosInXML(file_access, logger)
                 change_macros_in_xml.add_macro(ioc_name, Macro("DISABLE_AUTOONOFF", "0"), "^(0|1)$", "Disable automatic PSU on/off feature", "1")
                 change_macros_in_xml.change_macros(ioc_name, [(Macro("DISABLE_AUTOONOFF"), Macro("DISABLE_AUTOONOFF", "0"))])

--- a/src/upgrade_step_from_6p0p0.py
+++ b/src/upgrade_step_from_6p0p0.py
@@ -14,9 +14,9 @@ class SetDanfysikDisableAutoonoffMacros(UpgradeStep):
             hostname = socket.gethostname()
             ioc_name = "DFKPS"
             if hostname=="NDXEMU":
-                macro_to_change = Macro("DISABLE_AUTOONOFF", "0")
                 change_macros_in_xml = ChangeMacrosInXML(file_access, logger)
-                change_macros_in_xml.change_specific_macros(ioc_name, macro_to_change)
-            return 0
-        except:
+                change_macros_in_xml.change_macros(ioc_name, [(Macro("DISABLE_AUTOONOFF"), Macro("DISABLE_AUTOONOFF", "0"))])
+                return 0
+        except Exception as e:
+            logger.error("Unable to perform upgrade, caught error: {}".format(e))
             return 1

--- a/test/test_xml_macro_changer.py
+++ b/test/test_xml_macro_changer.py
@@ -499,6 +499,85 @@ class TestChangeIOCName(unittest.TestCase):
         assert_that((unchanged_ioc in output_file), is_(True))
 
 
+class TestAddMacro(unittest.TestCase):
+    def setUp(self):
+        self.file_access = FileAccessStub()
+        self.logger = LoggingStub()
+        self.macro_changer = ChangeMacrosInXML(self.file_access, self.logger)
+
+    def test_GIVEN_one_ioc_THEN_add_macro(self):
+        # Given:
+        xml = IOC_FILE_XML.format(iocs=create_galil_ioc(1, {"GALILADDR": "0", "MTRCTRL": "0"}))
+        ioc_name = "GALIL"
+        macro_to_add = Macro("TEST", "1")
+        pattern = "^(0|1)$"
+        description = "Test description"
+        default = "0"
+
+        self.file_access.open_file = Mock(return_value=xml)
+        self.file_access.write_file = Mock()
+        self.file_access.get_config_files = Mock(return_value=[("file1.xml", self.file_access.open_xml_file(None))])
+
+        # When:
+        self.macro_changer.add_macro(ioc_name, macro_to_add, pattern, description, default)
+
+        # Then:
+        written_xml = ET.fromstring(self.file_access.write_file_contents)
+        result_galiladdr = written_xml.findall(".//ns:macros/*[@name='GALILADDR']", {"ns": NAMESPACE})
+        result_mtrctrl = written_xml.findall(".//ns:macros/*[@name='MTRCTRL']", {"ns": NAMESPACE})
+        result_test = written_xml.findall(".//ns:macros/*[@name='TEST']", {"ns": NAMESPACE})
+
+        assert_that(result_galiladdr, has_length(1), "changed macro count")
+        assert_that(result_galiladdr[0].get("name"), is_("GALILADDR"))
+        assert_that(result_galiladdr[0].get("value"), is_("0"))
+
+        assert_that(result_mtrctrl, has_length(1), "changed macro count")
+        assert_that(result_mtrctrl[0].get("name"), is_("MTRCTRL"))
+        assert_that(result_mtrctrl[0].get("value"), is_("0"))
+
+        assert_that(result_test, has_length(1), "changed macro count")
+        assert_that(result_test[0].get("name"), is_(macro_to_add.name))
+        assert_that(result_test[0].get("value"), is_(macro_to_add.value))
+        assert_that(result_test[0].get("pattern"), is_(pattern))
+        assert_that(result_test[0].get("description"), is_(description))
+        assert_that(result_test[0].get("defaultValue"), is_(default))
+        assert_that(result_test[0].get("hasDefault"), is_("yes"))
+
+    def test_GIVEN_one_ioc_that_already_has_macro_THEN_dont_add_macro(self):
+        # Given:
+        xml = IOC_FILE_XML.format(iocs=create_galil_ioc(1, {"GALILADDR": "0", "MTRCTRL": "0", "TEST": "0"}))
+        ioc_name = "GALIL"
+        macro_to_add = Macro("TEST", "1")
+        pattern = "^(0|1)$"
+        description = "Test description"
+        default = "0"
+
+        self.file_access.open_file = Mock(return_value=xml)
+        self.file_access.write_file = Mock()
+        self.file_access.get_config_files = Mock(return_value=[("file1.xml", self.file_access.open_xml_file(None))])
+
+        # When:
+        self.macro_changer.add_macro(ioc_name, macro_to_add, pattern, description, default)
+
+        # Then:
+        written_xml = ET.fromstring(self.file_access.write_file_contents)
+        result_galiladdr = written_xml.findall(".//ns:macros/*[@name='GALILADDR']", {"ns": NAMESPACE})
+        result_mtrctrl = written_xml.findall(".//ns:macros/*[@name='MTRCTRL']", {"ns": NAMESPACE})
+        result_test = written_xml.findall(".//ns:macros/*[@name='TEST']", {"ns": NAMESPACE})
+
+        assert_that(result_galiladdr, has_length(1), "changed macro count")
+        assert_that(result_galiladdr[0].get("name"), is_("GALILADDR"))
+        assert_that(result_galiladdr[0].get("value"), is_("0"))
+
+        assert_that(result_mtrctrl, has_length(1), "changed macro count")
+        assert_that(result_mtrctrl[0].get("name"), is_("MTRCTRL"))
+        assert_that(result_mtrctrl[0].get("value"), is_("0"))
+
+        assert_that(result_test, has_length(1), "changed macro count")
+        assert_that(result_test[0].get("name"), is_("TEST"))
+        assert_that(result_test[0].get("value"), is_("0"))
+
+
 if __name__ == '__main__':
 
     unittest.main()

--- a/test/test_xml_macro_changer.py
+++ b/test/test_xml_macro_changer.py
@@ -538,10 +538,6 @@ class TestAddMacro(unittest.TestCase):
         assert_that(result_test, has_length(1), "changed macro count")
         assert_that(result_test[0].get("name"), is_(macro_to_add.name))
         assert_that(result_test[0].get("value"), is_(macro_to_add.value))
-        assert_that(result_test[0].get("pattern"), is_(pattern))
-        assert_that(result_test[0].get("description"), is_(description))
-        assert_that(result_test[0].get("defaultValue"), is_(default))
-        assert_that(result_test[0].get("hasDefault"), is_("yes"))
 
     def test_GIVEN_one_ioc_that_already_has_macro_THEN_dont_add_macro(self):
         # Given:

--- a/upgrade.py
+++ b/upgrade.py
@@ -36,7 +36,7 @@ UPGRADE_STEPS = [
     ("5.0.1", UpgradeMotionSetpoints()),
     ("5.0.2", UpgradeExpDatabase()),
     ("5.1.0", RemoveOldExpPopulator()),
-    ("5.1.0.1", UpgradeStepNoOp()),
+    ("5.1.0.1", UpgradeArchiveUseMediumBlob()),
     ("5.1.0.2", UpgradeStepNoOp()),
     ("5.1.1", UpgradeMOXA1210IOCs()),  # should have been 5.1.0.3 but we cant change it now
     ("5.1.1.1", UpgradeMOXA12XXMacros()),

--- a/upgrade.py
+++ b/upgrade.py
@@ -10,6 +10,7 @@ from src.upgrade_step_from_5p0p1 import UpgradeMotionSetpoints, UpgradeExpDataba
 from src.upgrade_step_from_5p1p0 import RemoveOldExpPopulator
 from src.upgrade_step_from_5p4p1 import UpgradeBannerXml
 from src.upgrade_step_from_5p6p0 import ChangeConfigurationSchema, CopyDashboardDatabase
+from src.upgrade_step_from_6p0p0 import SetDanfysikDisableAutoonoffMacros
 from src.upgrade_step_ITC_PVs import ChangeITCPVs
 from src.upgrade_step_rename_moxa1210 import UpgradeMOXA1210IOCs
 from src.upgrade_step_change_moxa12XX_macros import UpgradeMOXA12XXMacros
@@ -33,9 +34,9 @@ UPGRADE_STEPS = [
     ("4.4.1", UpgradeStepNoOp()),
     ("5.0.0", UpgradeStepNoOp()),
     ("5.0.1", UpgradeMotionSetpoints()),
-    ("5.0.2", UpgradeExpDatabase()),
+    ("5.0.2", UpgradeStepNoOp()),
     ("5.1.0", RemoveOldExpPopulator()),
-    ("5.1.0.1", UpgradeArchiveUseMediumBlob()),
+    ("5.1.0.1", UpgradeStepNoOp()),
     ("5.1.0.2", UpgradeStepNoOp()),
     ("5.1.1", UpgradeMOXA1210IOCs()),  # should have been 5.1.0.3 but we cant change it now
     ("5.1.1.1", UpgradeMOXA12XXMacros()),
@@ -50,7 +51,8 @@ UPGRADE_STEPS = [
     ("5.6.0.3", UpgradeStepCheckInitInst()),
     ("5.6.0.4", CopyDashboardDatabase()),
     ("5.6.0.5", UpgradeStepNoOp()),
-    ("6.0.0", None),
+    ("6.0.0", SetDanfysikDisableAutoonoffMacros()),
+    ("6.0.0.1", None)
 
     # to add step see https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Config-Upgrader#adding-an-upgrade-step
 ]

--- a/upgrade.py
+++ b/upgrade.py
@@ -34,7 +34,7 @@ UPGRADE_STEPS = [
     ("4.4.1", UpgradeStepNoOp()),
     ("5.0.0", UpgradeStepNoOp()),
     ("5.0.1", UpgradeMotionSetpoints()),
-    ("5.0.2", UpgradeStepNoOp()),
+    ("5.0.2", UpgradeExpDatabase()),
     ("5.1.0", RemoveOldExpPopulator()),
     ("5.1.0.1", UpgradeStepNoOp()),
     ("5.1.0.2", UpgradeStepNoOp()),


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/5268

Added a step to the config upgrade script to set the Danfysik PSU DFKPS_01 IOC's DISABLE_AUTONOFF macro to 0 for the EMU instrument, allowing PSU auto on/off to be enabled.

If you want to test that this works on your local machine, you should comment out the if statement requiring the "NDXEMU" hostname in the upgrade class that I added.