### PR TITLE
Ticket3209 rcptt_ Synoptics are committed to git  

### DIFF
--- a/src/file_access.py
+++ b/src/file_access.py
@@ -54,7 +54,7 @@ class FileAccess(object):
             self._logger.info("Writing new version number {0}".format(version))
             f.write("{}\n".format(version))
 
-    def write_file(self, filename, file_contents):
+    def write_file(self, filename, file_contents, mode = "w"):
         """
         Write file contents (will overwrite existing files)
 
@@ -65,10 +65,20 @@ class FileAccess(object):
         Returns:
 
         """
-        with open(os.path.join(self.config_base, filename), mode="w") as f:
+        with open(os.path.join(self.config_base, filename), mode=mode) as f:
             self._logger.info("Writing file {0}".format(filename))
             for line in file_contents:
                 f.write("{}\n".format(line))
+
+    def line_exists(self, filename, string):
+        """
+        Check if string exists as a line in file
+        """
+        with open(os.path.join(self.config_base, filename), "r") as f:
+            for line in f:
+                if line == string:
+                    return True
+        return False
 
     def open_xml_file(self, filename):
         """

--- a/src/upgrade_step_from_7p2p0.py
+++ b/src/upgrade_step_from_7p2p0.py
@@ -1,0 +1,52 @@
+import socket
+import os
+
+from src.common_upgrades.change_macros_in_xml import ChangeMacrosInXML
+from src.common_upgrades.utils.macro import Macro
+from src.upgrade_step import UpgradeStep
+
+
+class IgnoreRcpttSynoptics(UpgradeStep):
+    """
+    Adds "rcptt_*" files to .gitignore, so that test synoptics are no longer committed.
+    """
+
+    ERROR_CODE = -1
+    SUCCESS_CODE = 0
+    file_name = ".gitignore"
+    text_content = ['*.py[co]',
+                    'rcptt_*/',
+                    'rcptt_*',
+                    '*.swp',
+                    '*~',
+                    '.idea/',
+                    '.project/']
+
+    def perform(self, file_access, logger):
+        """
+        Perform the upgrade step
+        Args:
+            file_access (FileAccess): file access
+            logger (LocalLogger): logger
+
+        Returns: exit code 0 success; anything else fail
+
+        """
+        try:
+            logger.info("Starting step ...")
+
+            if not file_access.exists(self.file_name):
+                # In case there isn't a .gitignore file, write new one
+                print(".gitignore not found at " + self.file_name + ", making a new .gitignore")
+                file_access.write_file(self.file_name, self.text_content, "w")
+            else:
+                # If existing .gitignore file is found, append to it
+                if not file_access.line_exists(self.file_name, "rcptt_*\n"):
+                    file_access.write_file(self.file_name, ["rcptt_*"], "a")
+
+            logger.info("Step completed")
+            return self.SUCCESS_CODE
+
+        except Exception as e:
+            logger.error("Unable to perform upgrade, caught error: {}".format(e))
+            return self.ERROR_CODE

--- a/test/test_upgrade_step_from_7p2p0.py
+++ b/test/test_upgrade_step_from_7p2p0.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+from mock import MagicMock as Mock
+from mock import ANY
+from mother import LoggingStub, FileAccessStub
+from src.upgrade_step_from_7p2p0 import IgnoreRcpttSynoptics
+
+
+class TestIgnoreRcpttSynoptics(unittest.TestCase):
+
+    def setUp(self):
+        self.file_access = FileAccessStub()
+        self.upgrade_step = IgnoreRcpttSynoptics()
+        self.logger = LoggingStub()
+
+    def test_GIVEN_existing_file_with_no_existing_rpctt_WHEN_writing_content_THEN_append_content(self):
+        self.file_access.exists = Mock(return_value=True)
+        self.file_access.write_file = Mock()
+        self.file_access.line_exists = Mock(return_value=False)
+        self.upgrade_step.perform(self.file_access, self.logger)
+        self.file_access.write_file.assert_called_once_with(self.upgrade_step.file_name, ["rcptt_*"], "a")
+
+    def test_GIVEN_no_file_WHEN_writing_content_THEN_write_to_new_file(self):
+        self.file_access.exists = Mock(return_value=False)
+        self.file_access.write_file = Mock()
+        # self.file_access.line_exists = Mock(return_value=False)
+        self.upgrade_step.perform(self.file_access, self.logger)
+        self.file_access.write_file.assert_called_once_with(self.upgrade_step.file_name,
+                                                            self.upgrade_step.text_content, "w")
+
+    def test_GVEN_existing_file_with_rpctt_WHEN_writing_content_THEN_do_nothing(self):
+        self.file_access.exists = Mock(return_value=True)
+        self.file_access.write_file = Mock()
+        self.file_access.line_exists = Mock(return_value=True)
+        self.upgrade_step.perform(self.file_access, self.logger)
+        self.file_access.write_file.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/upgrade.py
+++ b/upgrade.py
@@ -11,6 +11,7 @@ from src.upgrade_step_from_5p1p0 import RemoveOldExpPopulator
 from src.upgrade_step_from_5p4p1 import UpgradeBannerXml
 from src.upgrade_step_from_5p6p0 import ChangeConfigurationSchema, CopyDashboardDatabase
 from src.upgrade_step_from_6p0p0 import SetDanfysikDisableAutoonoffMacros
+from src.upgrade_step_from_7p2p0 import IgnoreRcpttSynoptics
 from src.upgrade_step_ITC_PVs import ChangeITCPVs
 from src.upgrade_step_rename_moxa1210 import UpgradeMOXA1210IOCs
 from src.upgrade_step_change_moxa12XX_macros import UpgradeMOXA12XXMacros
@@ -55,7 +56,8 @@ UPGRADE_STEPS = [
     ("6.0.0.1", UpgradeStepNoOp()),
     ("7.0.0", UpgradeStepNoOp()),
     ("7.1.0", UpgradeStepNoOp()),
-    ("7.2.0", None)
+    ("7.2.0", IgnoreRcpttSynoptics()),
+    ("7.2.0.1", None)
 
     # to add step see https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Config-Upgrader#adding-an-upgrade-step
 ]


### PR DESCRIPTION
### Description of work

Added upgrade step for release 7.2.0 which adds `rcptt_*` files to instrument configuration .gitignore, so that test synoptics are no longer committed

### To test

[Ticket 3209](https://github.com/ISISComputingGroup/IBEX/issues/3209)

### Acceptance criteria

All files beginning with `rcptt_` are ignored by git.

#### For example:
* In the GUI go to synoptic->New
* Save a synoptic as `rcptt_something`
* In `C:\Instrument\Settings\congfig\NDXXX\configurations\synoptics` confirm that the `rcptt_` synoptic is ignored by git

Unittests also available: `test_upgrade_step_from_7p2p0.py`

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
