### PR TITLE
Update upgrade.py

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -57,7 +57,7 @@ UPGRADE_STEPS = [
     ("7.0.0", UpgradeStepNoOp()),
     ("7.1.0", UpgradeStepNoOp()),
     ("7.2.0", IgnoreRcpttSynoptics()),
-    ("7.2.0.1", None)
+    ("7.2.1", None)
 
     # to add step see https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Config-Upgrader#adding-an-upgrade-step
 ]


### PR DESCRIPTION
When release 7.2.1 was created there was no 7.2.1 in the upgrade script so the config wasn't set to the correct version number. Here add the version number into upgrade.py