### PR TITLE
Ignore device screens if file doesn't exist

### DIFF
--- a/src/common_upgrades/synoptics_and_device_screens.py
+++ b/src/common_upgrades/synoptics_and_device_screens.py
@@ -38,7 +38,8 @@ class SynopticsAndDeviceScreens(object):
                     result = -2
                     break
             try:
-                self._update_keys_in_device_screens(device_screens[0], device_screens[1], keys_to_update)
+                if device_screens:
+                    self._update_keys_in_device_screens(device_screens[0], device_screens[1], keys_to_update)
             except Exception as e:
                 self.logger.error("Cannot upgrade device screens {}: {}".format(path, e))
                 result = -2

--- a/src/file_access.py
+++ b/src/file_access.py
@@ -193,10 +193,13 @@ class FileAccess(object):
 
     def get_device_screens(self):
         """
-        Returns the device screen file.
+        Returns the device screen file if it exists, else None.
         """
         device_screens_path = os.path.join(DEVICE_SCREENS_FOLDER, DEVICE_SCREEN_FILE)
-        return device_screens_path, self._get_xml(device_screens_path)
+        if os.path.exists(device_screens_path):
+            return device_screens_path, self._get_xml(device_screens_path)
+        else:
+            return None
 
 
 class CachingFileAccess(object):


### PR DESCRIPTION
Fixes crashes seen in build servers (https://epics-jenkins.isis.rl.ac.uk/job/System_Tests_debug/356/console).

To test:
* Rename your device screens file/folder
* Run the upgrade script
* Confirm it doesn't crash