### PR TITLE
Remove references to six

### DIFF
--- a/src/common_upgrades/change_pvs_in_xml.py
+++ b/src/common_upgrades/change_pvs_in_xml.py
@@ -1,5 +1,4 @@
 from src.common_upgrades.utils.constants import BLOCK_FILE
-import six
 
 
 class ChangePVsInXML(object):

--- a/src/file_access.py
+++ b/src/file_access.py
@@ -2,7 +2,6 @@ import os
 from xml.dom import minidom
 import shutil
 from xml.parsers.expat import ExpatError
-import six
 from src.common_upgrades.utils.constants import CONFIG_FOLDER, COMPONENT_FOLDER, SYNOPTIC_FOLDER, \
     DEVICE_SCREEN_FILE, DEVICE_SCREENS_FOLDER
 
@@ -288,7 +287,7 @@ class CachingFileAccess(object):
         Returns:
             contents of file as an xml tree
         """
-        if filename in six.iterkeys(self.cached_writes):
+        if filename in self.cached_writes.keys():
             return self.cached_writes[filename]
         else:
             return self.old_open_method(filename)
@@ -307,5 +306,5 @@ class CachingFileAccess(object):
         """
         Write all cached writes to the file.
         """
-        for filename, xml in six.iteritems(self.cached_writes):
+        for filename, xml in self.cached_writes.items():
             self._file_access.write_xml_file(filename, xml)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,3 @@
-import six
 from hamcrest import *
 from src.common_upgrades.utils.constants import BLOCK_FILE
 
@@ -79,5 +78,5 @@ def test_changing_synoptics_and_blocks(file_access, action, starting_blocks, exp
 def test_action_does_not_write(file_access, action, starting_blocks):
     _set_starting_blocks_and_perform_action(file_access, action, starting_blocks)
 
-    assert_that(file_access.SYNOPTIC_FILENAME, not_(is_in(six.iterkeys(file_access.write_file_dict))))
-    assert_that(BLOCK_FILE, not_(is_in(six.iterkeys(file_access.write_file_dict))))
+    assert_that(file_access.SYNOPTIC_FILENAME, not_(is_in(file_access.write_file_dict.keys())))
+    assert_that(BLOCK_FILE, not_(is_in(file_access.write_file_dict.keys())))


### PR DESCRIPTION
### Description of work

Remove all references to Six

### To test
[Ticket](https://github.com/ISISComputingGroup/IBEX/issues/8297)

### Acceptance criteria

- [ ] Git grep finds no `import six`.
- [ ] Tests pass