### PR TITLE
add upgrade step for CAENV895

### DIFF
--- a/src/upgrade_step_from_14p0p0.py
+++ b/src/upgrade_step_from_14p0p0.py
@@ -1,0 +1,28 @@
+import socket
+
+from src.common_upgrades.change_macros_in_xml import ChangeMacrosInXML
+from src.common_upgrades.utils.macro import Macro
+from src.upgrade_step import UpgradeStep
+
+
+class UpgradeFrom14p0p0(UpgradeStep):
+    """Set CARDS0 macro for all instruments  except ARGUS/CHRONUS in which it is  configured differently already"""
+
+    def perform(self, file_access, logger):
+        try:
+            hostname = socket.gethostname()
+            # Make sure we do not perform this on ARGUS/CHRONUS where the macro is already present
+            if hostname not in ["NDXARGUS", "NDXCHRONUS"]:
+                ioc_name = "CAENV895"
+                change_macros_in_xml = ChangeMacrosInXML(file_access, logger)
+                change_macros_in_xml.add_macro(
+                    ioc_name,
+                    Macro("CARDS", "6"),
+                    "^[0-9]+$",
+                    "Number of cards in crate 0, leave blank if this crate does not exist",
+                    "Yes",
+                )
+            return 0
+        except Exception as e:
+            logger.error("Unable to perform upgrade, caught error: {}".format(e))
+            return 1

--- a/upgrade.py
+++ b/upgrade.py
@@ -20,6 +20,7 @@ from src.upgrade_step_from_12p0p0 import UpgradeJawsForPositionAutosave
 from src.upgrade_step_from_12p0p1 import AddOscCollimMovingIndicator
 from src.upgrade_step_from_12p0p2 import UpgradeFrom12p0p2
 from src.upgrade_step_from_12p0p3 import UpgradeFrom12p0p3
+from src.upgrade_step_from_14p0p0 import UpgradeFrom14p0p0
 from src.upgrade_step_noop import UpgradeStepNoOp
 
 # A list of upgrade step tuples tuple is name of version to apply the upgrade to and upgrade class.
@@ -70,7 +71,8 @@ UPGRADE_STEPS = [
     ("12.0.3", UpgradeFrom12p0p3()),
     ("13.0.0", UpgradeStepNoOp()),
     ("13.0.1", UpgradeStepNoOp()),
-    ("14.0.0", None),
+    ("14.0.0", UpgradeFrom14p0p0()),
+    ("15.0.0", None)
     # to add step see https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Config-Upgrader#adding-an-upgrade-step
 ]
 


### PR DESCRIPTION
Adds an upgrade step for the new CARDS macro, to ensure devices which already exist  still work with a default of  6 cards