### PR TITLE
remove copying sm300 and beckhoff dirs in upgrade_step_from_15p0p0.py

### DIFF
--- a/src/upgrade_step_from_15p0p0.py
+++ b/src/upgrade_step_from_15p0p0.py
@@ -12,10 +12,8 @@ CONTROLLERS = [
     "galil",
     "galilmul",
     "mclennan",
-    "bkhoff_01",
     "linmot",
     "smc100_01",
-    "sm300_01",
     "twincat",
 ]
 


### PR DESCRIPTION
These are no longer used and therefore there's no point copying configuration over. 