### PR TITLE
remove adding FWDR and BSKAFKA to base component

### DIFF
--- a/src/upgrade_step_from_25p2p1p1.py
+++ b/src/upgrade_step_from_25p2p1p1.py
@@ -44,4 +44,4 @@ class UpgradeFrom25p2p1p1(UpgradeStep):
 
         reader.write_file(file)
 
-        return pass_fail 
+        return pass_fail

--- a/src/upgrade_step_from_25p2p1p1.py
+++ b/src/upgrade_step_from_25p2p1p1.py
@@ -1,5 +1,4 @@
 from src.common_upgrades import change_pv_in_dashboard as dashboard
-from src.common_upgrades.add_to_base_iocs import AddToBaseIOCs
 from src.file_access import FileAccess
 from src.local_logger import LocalLogger
 from src.upgrade_step import UpgradeStep
@@ -45,8 +44,4 @@ class UpgradeFrom25p2p1p1(UpgradeStep):
 
         reader.write_file(file)
 
-        base_ioc_add_success = AddToBaseIOCs("FWDR", "BSKAFKA", XML_TO_ADD).perform(
-            file_access, logger
-        )
-
-        return pass_fail | base_ioc_add_success
+        return pass_fail 


### PR DESCRIPTION
This is mainly for the next set of instruments to be deployed to - i've just spent a while manually removing BSKAFKA and FWDR from their base components as they are no longer needed, this PR is to remove re-adding them. 